### PR TITLE
fix(build): Adjust webpack config and sass imports for sass build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,27 +94,27 @@
       }
     },
     "@storybook/addon-actions": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.16.tgz",
-      "integrity": "sha512-TXR/H5lDCtPCmc+/nidvVBiTlGsPHxeJ/LMPuGxq/yF7EvzrfXw+CuEuaPNp5qknSioOLm9GngbozNg8HfBgKg==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.17.tgz",
+      "integrity": "sha512-B4++4+p6zWTeTBzqe9lgzT8J0onaMfSZsBRJpa5URoDo3d4kTq+DTDs2qHhhTKJb2Drtu24/JlEgJG7lv0Fb0w==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "3.2.16",
+        "@storybook/addons": "3.2.17",
         "deep-equal": "1.0.1",
         "json-stringify-safe": "5.0.1",
         "prop-types": "15.6.0",
-        "react-inspector": "2.2.1",
+        "react-inspector": "2.2.2",
         "uuid": "3.1.0"
       }
     },
     "@storybook/addon-info": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-3.2.16.tgz",
-      "integrity": "sha512-6/kmhuB3VJedhKI+CueYgB3jdkQQvprlPLQA2ckzFexsBs4kYtKh7qqGtIVdjnZmME1IMXiEZUuPpEZdqLNVDg==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-3.2.17.tgz",
+      "integrity": "sha512-MHZv/lam+NYyibOIRly+66GPSmlhrGMDlQaZFliXYILQuF6skN4KeC/A7IkhquAUVA2PrkBS8EJfTAV0Qw0pcQ==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "3.2.16",
-        "@storybook/components": "3.2.16",
+        "@storybook/addons": "3.2.17",
+        "@storybook/components": "3.2.17",
         "babel-runtime": "6.26.0",
         "global": "4.3.2",
         "marksy": "2.0.1",
@@ -129,56 +129,56 @@
       "integrity": "sha512-Xnd54kx47boM5Xl0sVMqblcki3Z8Z9hS8CIWz5CCJCfxQKx7mhFtcOmHrIqUH2oUZhhFSj+aFrRx1zPcFcPaZQ==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "3.2.16",
+        "@storybook/addons": "3.2.17",
         "babel-runtime": "6.26.0",
         "deep-equal": "1.0.1",
         "global": "4.3.2",
         "insert-css": "1.1.0",
         "lodash.debounce": "4.0.8",
-        "moment": "2.19.2",
+        "moment": "2.19.4",
         "prop-types": "15.6.0",
         "react-color": "2.13.8",
-        "react-datetime": "2.11.0",
+        "react-datetime": "2.11.1",
         "react-textarea-autosize": "4.3.2",
         "util-deprecate": "1.0.2"
       }
     },
     "@storybook/addon-links": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.16.tgz",
-      "integrity": "sha512-JFs2p7EGRFpwUkg7xV7Vi3h/zBr4UjmprF9YYHR2L5TQFbztlKJPBhiATRSQtgFyNNAo7zNkSf439Rkrb9k7yQ==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.17.tgz",
+      "integrity": "sha512-AdCH9DsbOfiMDv42/l0Zfk2yhiBrlWuzHk7ubhSwqF3/61sXr+BWFv+SlOx2oFfSWAT7zfg2sC7Wr+us8gs7GQ==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "3.2.16"
+        "@storybook/addons": "3.2.17"
       }
     },
     "@storybook/addons": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.16.tgz",
-      "integrity": "sha512-Dxs0XceqqUSG+vao5uCZdphmCAGlpnwDLV0abjYpPH0eKb2QN5Rs/Vrl0MzuOYGghPv8Y1QfhdB6DFh7AuIoTQ==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.17.tgz",
+      "integrity": "sha512-1/Ux++3hMfYqAgBwgWbGtGAM0CfSdAchf//wDLBUmX09+E5CjiQvW3YwVplNYzfRuAsSrE1GOYJRAsz639oTYQ==",
       "dev": true
     },
     "@storybook/channel-postmessage": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.2.16.tgz",
-      "integrity": "sha512-8D3UeZfb4TarkEp0xMCUxX5rW/m2YghYmlnFDcMCgPhN9R2pRySjxxbCjK+ry0q2hUII4R9Bbck63AUqwcQDow==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.2.17.tgz",
+      "integrity": "sha512-sNlXcHTKM6aIxRsQMaMbowsAToYRlbeP/THqulVxoRRKNDPndNnZe/Lu3eSjBjAfNWBLRFfgX903adt82QAPCA==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "3.2.16",
+        "@storybook/channels": "3.2.17",
         "global": "4.3.2",
         "json-stringify-safe": "5.0.1"
       }
     },
     "@storybook/channels": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.16.tgz",
-      "integrity": "sha512-zjaDE/0yvlLfOcpzeTIWi1K7d873UykUmGLwFSO2hUIM7hlc+QxCeE0MH+OrQYUWC8gcU8pg+IWAk/6qzWAZsA==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.17.tgz",
+      "integrity": "sha512-HIdRmFTFVLcbrwYFf6+LyAlgcd57ki+6DDTmcvXQTHCWrOOCJKwfKjHgn6tbnHlGHiWByA8lAdO1bFcYhHxl4Q==",
       "dev": true
     },
     "@storybook/components": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.16.tgz",
-      "integrity": "sha512-+bxwsvwa7TPqwxG6ap2hjjrwSg1g8e2ZGijPQDEGpvNfEnLfbZRyQKXRhfCyeAN3DL8F8Bx95AJuWaYKr0pqpA==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.17.tgz",
+      "integrity": "sha512-pXwNKLavYCu18B2EynFu9EKXlKi0LDo0B/KctbJvidxR5ubzqkZu9h2ti3hPPVomR2DQiRx61Vzqd7cbcyy14w==",
       "dev": true,
       "requires": {
         "glamor": "2.20.40",
@@ -193,7 +193,7 @@
       "dev": true,
       "requires": {
         "@storybook/react-komposer": "2.0.3",
-        "@storybook/react-simple-di": "1.2.1",
+        "@storybook/react-simple-di": "1.3.0",
         "babel-runtime": "6.26.0"
       }
     },
@@ -203,13 +203,13 @@
       "integrity": "sha512-/TWoVYHfoUnEAjcEj463zRIA7SJjB6RIzShFzI2HtJw+P2EdT8mFN2EYGdsuGHQqkbGSC3owHSy1Jxuy1GVuqQ==",
       "dev": true,
       "requires": {
-        "@storybook/addon-actions": "3.2.16",
-        "@storybook/addon-links": "3.2.16",
-        "@storybook/addons": "3.2.16",
-        "@storybook/channel-postmessage": "3.2.16",
-        "@storybook/ui": "3.2.16",
-        "airbnb-js-shims": "1.3.0",
-        "autoprefixer": "7.1.6",
+        "@storybook/addon-actions": "3.2.17",
+        "@storybook/addon-links": "3.2.17",
+        "@storybook/addons": "3.2.17",
+        "@storybook/channel-postmessage": "3.2.17",
+        "@storybook/ui": "3.2.17",
+        "airbnb-js-shims": "1.4.0",
+        "autoprefixer": "7.2.2",
         "babel-core": "6.26.0",
         "babel-loader": "7.1.2",
         "babel-plugin-react-docgen": "1.8.1",
@@ -223,10 +223,10 @@
         "babel-runtime": "6.26.0",
         "case-sensitive-paths-webpack-plugin": "2.1.1",
         "chalk": "2.3.0",
-        "commander": "2.11.0",
-        "common-tags": "1.4.0",
+        "commander": "2.12.2",
+        "common-tags": "1.5.1",
         "configstore": "3.1.1",
-        "core-js": "2.5.1",
+        "core-js": "2.5.3",
         "css-loader": "0.28.7",
         "express": "4.16.2",
         "file-loader": "0.11.2",
@@ -240,7 +240,7 @@
         "lodash.flattendeep": "4.4.0",
         "lodash.pick": "4.4.0",
         "postcss-flexbugs-fixes": "3.2.0",
-        "postcss-loader": "2.0.8",
+        "postcss-loader": "2.0.9",
         "prop-types": "15.6.0",
         "qs": "6.5.1",
         "react-modal": "2.4.1",
@@ -252,9 +252,9 @@
         "url-loader": "0.5.9",
         "util-deprecate": "1.0.2",
         "uuid": "3.1.0",
-        "webpack": "3.9.1",
-        "webpack-dev-middleware": "1.12.0",
-        "webpack-hot-middleware": "2.20.0"
+        "webpack": "3.10.0",
+        "webpack-dev-middleware": "1.12.2",
+        "webpack-hot-middleware": "2.21.0"
       },
       "dependencies": {
         "style-loader": {
@@ -295,13 +295,15 @@
       }
     },
     "@storybook/react-simple-di": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.2.1.tgz",
-      "integrity": "sha512-Sj3JU1KpnTIyBWBp+uAZT3PlZ2IVYrxvOOXgpT92Injcmg2KV2ry1GkZen6XuVZqUfU0vz/sK08aP45boErFnw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.3.0.tgz",
+      "integrity": "sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
-        "hoist-non-react-statics": "1.2.0"
+        "create-react-class": "15.6.2",
+        "hoist-non-react-statics": "1.2.0",
+        "prop-types": "15.6.0"
       }
     },
     "@storybook/react-stubber": {
@@ -314,9 +316,9 @@
       }
     },
     "@storybook/storybook-deployer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/storybook-deployer/-/storybook-deployer-2.0.0.tgz",
-      "integrity": "sha1-SeO/wT/1xwguQEQUnJ0gMvDWPp8=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@storybook/storybook-deployer/-/storybook-deployer-2.2.0.tgz",
+      "integrity": "sha512-N1nhYfb35gqphpHzJr6BXzglg2h9C3Y3UHt2JNSsHziwNKXUIxKkB0MF5tjnl0vD0DYL6soXvpZ+b76l8cxPAg==",
       "dev": true,
       "requires": {
         "git-url-parse": "6.2.2",
@@ -325,13 +327,13 @@
       }
     },
     "@storybook/ui": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.16.tgz",
-      "integrity": "sha512-K6DwvT2Oo4GrJkT0ij8EW1GsjX7Sw9U6hDp2II5tnKsV7egnIKgJ6y5xGOZLHNvDDkeo5KS+Ii3GjrUbnZ1QzQ==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.17.tgz",
+      "integrity": "sha512-At0oWWTALJrJhtdnP+0AMANBC5omIBnEg3Pin3M0+yzUy6Poelcvt8+81dQEKLBP6LiyFOVpiDjfqpiHR5l0ow==",
       "dev": true,
       "requires": {
         "@hypnosphi/fuse.js": "3.0.9",
-        "@storybook/components": "3.2.16",
+        "@storybook/components": "3.2.17",
         "@storybook/mantra-core": "1.7.2",
         "@storybook/react-fuzzy": "0.4.3",
         "@storybook/react-komposer": "2.0.3",
@@ -348,21 +350,22 @@
         "prop-types": "15.6.0",
         "qs": "6.5.1",
         "react-icons": "2.2.7",
-        "react-inspector": "2.2.1",
-        "react-modal": "3.1.2",
+        "react-inspector": "2.2.2",
+        "react-modal": "3.1.7",
         "react-split-pane": "0.1.71",
         "react-treebeard": "2.1.0",
         "redux": "3.7.2"
       },
       "dependencies": {
         "react-modal": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.2.tgz",
-          "integrity": "sha512-a3L2qP0kaqMBy4C1aojs2caUIz3kHRFlnuWJ8zsnuUmh/fKHEDASujVBiQcatn+yUosdE9hViB6JvLfkB0tN2A==",
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.7.tgz",
+          "integrity": "sha512-pIVKqhPZxXqnewkQnjN0VJT0hn1XGJV2pwDJmKwAxPbfXZ1cAX79uO/Z3kYkpnb+2gAAusooK/AvnBjWuKQrRA==",
           "dev": true,
           "requires": {
             "exenv": "1.2.2",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.0",
+            "warning": "3.0.0"
           }
         }
       }
@@ -374,9 +377,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.25.tgz",
-      "integrity": "sha512-K79zMwWRzQ2db+nPoKpi3gA/KmLo6ZQgT4iO2QPEUdBO7as0PcgrmU9KHYzIO3V6lbD7gRjOM0/nUch6xBfOvQ==",
+      "version": "16.0.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.29.tgz",
+      "integrity": "sha512-ITI4e/2D3jrGr+wrtP8vlcdGPgUzUslx8m8c3jLh95g/L+lpZA+O6kegcEky4eEFbjD4EWyisEZ23QJNUJz+Nw==",
       "dev": true
     },
     "abab": {
@@ -477,12 +480,14 @@
       }
     },
     "airbnb-js-shims": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.3.0.tgz",
-      "integrity": "sha512-Y/9jgf3uEdNyeWPUV1N49FowM/qMIiKSTkRUpYT4jpHkSADfTiRVwI8Mm6o4CIxhnBK1uMf4RIYNYKwwILMCAQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.4.0.tgz",
+      "integrity": "sha512-KIlW3epMtB1x3PtJr2L7ltkoYvuKzjqrgZPq6mzJUL6Gz+3Y2Oc9FS9ZRzRWym2/jk1r+JsDOOyS2Vavc0E3Pw==",
       "dev": true,
       "requires": {
         "array-includes": "3.0.3",
+        "array.prototype.flatmap": "1.1.1",
+        "array.prototype.flatten": "1.1.1",
         "es5-shim": "4.5.9",
         "es6-shim": "0.35.3",
         "function.prototype.name": "1.0.3",
@@ -495,9 +500,9 @@
       }
     },
     "ajv": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
-      "integrity": "sha1-MtHPCNvIDEMvQm8S4QslEfa0ZHQ=",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
@@ -658,7 +663,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0"
+        "es-abstract": "1.10.0"
       }
     },
     "array-union": {
@@ -689,7 +694,29 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0"
+        "es-abstract": "1.10.0"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.1.1.tgz",
+      "integrity": "sha512-LYxij5OIk/e1wxCPu0Ng1Rtqpe3c1FmfQ/uS/2HGk9GfySnzEpJ4N8eKJgnTCI3PSBBsNNwbUORetjs7B+3oLA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1"
+      }
+    },
+    "array.prototype.flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatten/-/array.prototype.flatten-1.1.1.tgz",
+      "integrity": "sha512-9DM+ZgShl2O01ERvRiEqljn+UAOn5yUwvfdrhM/NBLxuh98+MN/6SyBpvIpJBA0UcUuayRl/5BhmZ4TyjlHqyg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1"
       }
     },
     "arrify": {
@@ -769,13 +796,13 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.6.tgz",
-      "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.2.tgz",
+      "integrity": "sha512-eTVoSHiGp2cDytg7RS7gtqAnfH+WFcNQMTjywGNu+hH7ViQZ/ZKsvNz2C1oVhCtd9DjMIC15iatpxmtp5Kxvpg==",
       "dev": true,
       "requires": {
-        "browserslist": "2.9.0",
-        "caniuse-lite": "1.0.30000769",
+        "browserslist": "2.10.0",
+        "caniuse-lite": "1.0.30000782",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.14",
@@ -805,8 +832,8 @@
         "babel-register": "6.26.0",
         "babel-runtime": "6.26.0",
         "chokidar": "1.7.0",
-        "commander": "2.11.0",
-        "convert-source-map": "1.5.0",
+        "commander": "2.12.2",
+        "convert-source-map": "1.5.1",
         "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
         "lodash": "4.17.4",
@@ -879,7 +906,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
+        "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.4",
@@ -1914,7 +1941,7 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
+        "core-js": "2.5.3",
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
@@ -1959,7 +1986,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.9.0",
+        "browserslist": "2.10.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -2134,7 +2161,7 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
+        "core-js": "2.5.3",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
@@ -2146,8 +2173,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-standalone": {
@@ -2317,53 +2344,6 @@
         "hoek": "4.2.0"
       }
     },
-    "bootstrap": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
-      "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E=",
-      "dev": true
-    },
-    "bootstrap-datepicker": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.6.4.tgz",
-      "integrity": "sha1-iJ6+ztjqov8V7B8nPksHUxzEPaA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jquery": "3.2.1"
-      }
-    },
-    "bootstrap-sass": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
-      "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg=",
-      "dev": true,
-      "optional": true
-    },
-    "bootstrap-select": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.12.4.tgz",
-      "integrity": "sha1-fxXTwM6XiGjZwJxw+WYk9V+gLuE=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jquery": "3.2.1"
-      }
-    },
-    "bootstrap-switch": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz",
-      "integrity": "sha1-cOCusqh3wNx2aZHeEI4hcPwpov8=",
-      "dev": true,
-      "optional": true
-    },
-    "bootstrap-touchspin": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz",
-      "integrity": "sha1-l3nerHKq9Xfl52K4USx0fIcdlZc=",
-      "dev": true,
-      "optional": true
-    },
     "bowser": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.8.1.tgz",
@@ -2491,13 +2471,13 @@
       }
     },
     "browserslist": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.0.tgz",
-      "integrity": "sha512-vJEBcDTANoDhSHL46NeOEW5hvQw7It9uCqzeFPQhpawXfnOwnpvW5C97vn1eGJ7iCkSg8wWU0nYObE7d/N95Iw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
+      "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000769",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-lite": "1.0.30000782",
+        "electron-to-chromium": "1.3.28"
       }
     },
     "bser": {
@@ -2543,16 +2523,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
-    },
-    "c3": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/c3/-/c3-0.4.18.tgz",
-      "integrity": "sha512-37TiFeCrbe69gg7SxFpTBOLDwulnk+opKp1AFDi43mONtErpRoUIZfGSimGiSYQmNu6Zh9W2yNOx0066UikqSg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "d3": "3.5.17"
-      }
     },
     "cachedir": {
       "version": "1.1.1",
@@ -2609,7 +2579,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000769",
+        "caniuse-db": "1.0.30000782",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -2620,22 +2590,22 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000769",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "1.0.30000782",
+            "electron-to-chromium": "1.3.28"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000769",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000769.tgz",
-      "integrity": "sha1-wjC5wbno2z4cDYWMluaFdBuWzBA=",
+      "version": "1.0.30000782",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000782.tgz",
+      "integrity": "sha1-2IFbzhV4w1Cs7REyUHMBIF4Pq1M=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000769.tgz",
-      "integrity": "sha1-1oxaoHcuo+rGyX1C4jnJtNMmG5M=",
+      "version": "1.0.30000782",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000782.tgz",
+      "integrity": "sha1-W4K4w4XyU0h0XEccpRMgr7G38lQ=",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -2895,9 +2865,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
     "commitizen": {
@@ -2998,7 +2968,7 @@
           "dev": true,
           "requires": {
             "glob": "7.1.1",
-            "interpret": "1.0.4",
+            "interpret": "1.1.0",
             "rechoir": "0.6.2"
           }
         },
@@ -3011,9 +2981,9 @@
       }
     },
     "common-tags": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
-      "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.5.1.tgz",
+      "integrity": "sha512-NrUYGY5TApAk9KB+IZXkR3GR4tA3g26HDsoiGt4kCMHZ727gOGkC+UNfq0Z22jE15bLkc/6RV5Jw1RBW6Usg6A==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
@@ -3048,7 +3018,7 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "proto-list": "1.2.4"
       }
     },
@@ -3156,9 +3126,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
     "cookie": {
@@ -3174,9 +3144,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3387,7 +3357,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -3492,7 +3462,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000769",
+            "caniuse-db": "1.0.30000782",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -3505,8 +3475,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000769",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "1.0.30000782",
+            "electron-to-chromium": "1.3.28"
           }
         },
         "chalk": {
@@ -3543,7 +3513,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -3626,15 +3596,8 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
-    },
-    "d3": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
-      "dev": true,
-      "optional": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -3643,60 +3606,6 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      }
-    },
-    "datatables.net": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.16.tgz",
-      "integrity": "sha1-SwUtEIKCQmG2ju2dInQbcR09JGk=",
-      "dev": true,
-      "requires": {
-        "jquery": "3.2.1"
-      }
-    },
-    "datatables.net-bs": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/datatables.net-bs/-/datatables.net-bs-1.10.16.tgz",
-      "integrity": "sha1-sIVPWzdPcTrj20FWx86op2DD3nY=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "datatables.net": "1.10.16",
-        "jquery": "3.2.1"
-      }
-    },
-    "datatables.net-colreorder": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.3.3.tgz",
-      "integrity": "sha1-/HYuNQ+UIkyyzUXCuWImGg//73I=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "datatables.net": "1.10.16",
-        "jquery": "3.2.1"
-      }
-    },
-    "datatables.net-colreorder-bs": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/datatables.net-colreorder-bs/-/datatables.net-colreorder-bs-1.3.3.tgz",
-      "integrity": "sha1-Op3LCN7r612FQHlZHgbkk615OlM=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "datatables.net-bs": "1.10.16",
-        "datatables.net-colreorder": "1.3.3",
-        "jquery": "3.2.1"
-      }
-    },
-    "datatables.net-select": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.2.3.tgz",
-      "integrity": "sha1-fCcugXMqQSFOEBtlb1Ul037Dcog=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "datatables.net": "1.10.16",
-        "jquery": "3.2.1"
       }
     },
     "date-now": {
@@ -3895,13 +3804,12 @@
       }
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
     },
     "dom-helpers": {
@@ -3930,16 +3838,6 @@
         "is-obj": "1.0.1"
       }
     },
-    "drmonty-datatables-colvis": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/drmonty-datatables-colvis/-/drmonty-datatables-colvis-1.1.2.tgz",
-      "integrity": "sha1-lque37SGQ8wu3aP4e4iTPN7oEnw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jquery": "3.2.1"
-      }
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -3963,9 +3861,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
+      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
     "elliptic": {
@@ -4015,26 +3913,13 @@
         "tapable": "0.2.8"
       }
     },
-    "eonasdan-bootstrap-datetimepicker": {
-      "version": "4.17.47",
-      "resolved": "https://registry.npmjs.org/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.47.tgz",
-      "integrity": "sha1-ekmXAEQGUnbnll79Fvgic1IZ5zU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bootstrap": "3.3.7",
-        "jquery": "3.2.1",
-        "moment": "2.19.2",
-        "moment-timezone": "0.4.1"
-      }
-    },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -4047,9 +3932,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -4071,9 +3956,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.35",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
-      "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+      "version": "0.10.37",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -4093,7 +3978,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-symbol": "3.1.1"
       }
     },
@@ -4104,7 +3989,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -4118,7 +4003,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -4137,7 +4022,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "es6-weak-map": {
@@ -4147,7 +4032,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -4214,7 +4099,7 @@
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
         "debug": "2.6.9",
-        "doctrine": "2.0.0",
+        "doctrine": "2.0.2",
         "escope": "3.6.0",
         "espree": "3.5.2",
         "esquery": "1.0.0",
@@ -4325,9 +4210,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.8.0.tgz",
-      "integrity": "sha512-XuCvdsC+n4jYPXxEyleaTF9wQR/rv5ofbrhTJiVAv+a91O9EcroicK74XHtbAYeopkF7i2EAH2GNLU48PnRIqw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
+      "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
       "dev": true,
       "requires": {
         "get-stdin": "5.0.1"
@@ -4562,7 +4447,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "event-stream": {
@@ -4955,19 +4840,6 @@
         "stream-consume": "0.1.0"
       }
     },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
-      "dev": true
-    },
-    "font-awesome-sass": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome-sass/-/font-awesome-sass-4.7.0.tgz",
-      "integrity": "sha1-TtppPpFQCc4Asijglk3F7Km8NOE=",
-      "dev": true,
-      "optional": true
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -5072,15 +4944,13 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5090,21 +4960,18 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5114,49 +4981,42 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5165,8 +5025,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -5174,8 +5033,7 @@
         },
         "boom": {
           "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -5183,8 +5041,7 @@
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
@@ -5193,34 +5050,29 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "bundled": true,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
@@ -5228,26 +5080,22 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "boom": "2.10.1"
@@ -5255,8 +5103,7 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5265,8 +5112,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -5274,8 +5120,7 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5284,35 +5129,30 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "bundled": true,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
-          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5321,28 +5161,24 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "bundled": true,
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5353,14 +5189,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -5371,8 +5205,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5383,8 +5216,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5400,8 +5232,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5410,8 +5241,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -5419,8 +5249,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5433,21 +5262,18 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5457,15 +5283,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "boom": "2.10.1",
@@ -5476,14 +5300,12 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "bundled": true,
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5494,8 +5316,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -5504,21 +5325,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -5526,28 +5344,24 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5556,22 +5370,19 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5580,22 +5391,19 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5607,8 +5415,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -5616,14 +5423,12 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "bundled": true,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mime-db": "1.27.0"
@@ -5631,8 +5436,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
@@ -5640,14 +5444,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -5655,15 +5457,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5682,8 +5482,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5693,8 +5492,7 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5706,28 +5504,24 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -5735,22 +5529,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5760,41 +5551,35 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "bundled": true,
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5806,8 +5591,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -5815,8 +5599,7 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -5830,8 +5613,7 @@
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5861,8 +5643,7 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -5870,35 +5651,30 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "bundled": true,
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -5906,8 +5682,7 @@
         },
         "sshpk": {
           "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5924,8 +5699,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -5933,8 +5707,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -5944,8 +5717,7 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -5953,15 +5725,13 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -5969,15 +5739,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -5987,8 +5755,7 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6004,8 +5771,7 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6014,8 +5780,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6024,35 +5789,30 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6061,8 +5821,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6071,8 +5830,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -6343,7 +6101,7 @@
       "dev": true,
       "requires": {
         "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "is-windows": "0.2.0",
         "which": "1.3.0"
       }
@@ -6386,13 +6144,6 @@
         "lodash": "4.17.4",
         "minimatch": "3.0.4"
       }
-    },
-    "google-code-prettify": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/google-code-prettify/-/google-code-prettify-1.0.5.tgz",
-      "integrity": "sha1-n0d/Ik2/piNy5e+AOn4VdBBAAIQ=",
-      "dev": true,
-      "optional": true
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -6447,7 +6198,7 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.4.0",
+        "ajv": "5.5.1",
         "har-schema": "2.0.0"
       }
     },
@@ -6741,9 +6492,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inline-style-prefixer": {
@@ -6823,9 +6574,9 @@
       "dev": true
     },
     "interpret": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "invariant": {
@@ -7016,13 +6767,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -8104,23 +7855,10 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
-      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=",
-      "dev": true
-    },
-    "jquery-match-height": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/jquery-match-height/-/jquery-match-height-0.7.2.tgz",
-      "integrity": "sha1-+NnzulMU2qsQnPB0CGdL4gS+Xw4=",
-      "dev": true,
-      "optional": true
-    },
     "js-base64": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
       "dev": true
     },
     "js-tokens": {
@@ -8431,15 +8169,10 @@
       "dev": true
     },
     "lodash.assign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -8643,9 +8376,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
+      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
       "dev": true
     },
     "marksy": {
@@ -8656,7 +8389,7 @@
       "requires": {
         "babel-standalone": "6.26.0",
         "he": "1.1.1",
-        "marked": "0.3.6"
+        "marked": "0.3.7"
       }
     },
     "material-colors": {
@@ -8714,7 +8447,7 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
+        "errno": "0.1.6",
         "readable-stream": "2.3.3"
       }
     },
@@ -8963,20 +8696,10 @@
       }
     },
     "moment": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
-      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA==",
+      "version": "2.19.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.4.tgz",
+      "integrity": "sha512-1xFTAknSLfc47DIxHDUbnJWC+UwgWxATmymaxIPQpmMh7LBm7ZbwVEsuushqwL2GYZU0jie4xO+TK44hJPjNSQ==",
       "dev": true
-    },
-    "moment-timezone": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
-      "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "moment": "2.19.2"
-      }
     },
     "ms": {
       "version": "2.0.0",
@@ -9059,15 +8782,6 @@
         "which": "1.3.0"
       },
       "dependencies": {
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -9249,7 +8963,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.11.0",
+            "commander": "2.12.2",
             "is-my-json-valid": "2.16.1",
             "pinkie-promise": "2.0.1"
           }
@@ -9282,12 +8996,6 @@
             "jsprim": "1.4.1",
             "sshpk": "1.13.1"
           }
-        },
-        "lodash.assign": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-          "dev": true
         },
         "qs": {
           "version": "6.3.2",
@@ -9347,13 +9055,12 @@
       }
     },
     "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.4"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -9440,7 +9147,7 @@
       "requires": {
         "config-chain": "1.1.11",
         "inherits": "2.0.3",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "once": "1.3.3",
@@ -9449,15 +9156,6 @@
         "uid-number": "0.0.5"
       },
       "dependencies": {
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        },
         "once": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
@@ -9540,7 +9238,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0",
+        "es-abstract": "1.10.0",
         "function-bind": "1.1.1",
         "has": "1.0.1"
       }
@@ -9552,7 +9250,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0"
+        "es-abstract": "1.10.0"
       }
     },
     "object.omit": {
@@ -9572,7 +9270,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0",
+        "es-abstract": "1.10.0",
         "function-bind": "1.1.1",
         "has": "1.0.1"
       }
@@ -9831,6 +9529,19 @@
       "requires": {
         "core-util-is": "1.0.2",
         "lodash.assign": "3.2.0"
+      },
+      "dependencies": {
+        "lodash.assign": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+          "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+          "dev": true,
+          "requires": {
+            "lodash._baseassign": "3.2.0",
+            "lodash._createassigner": "3.1.1",
+            "lodash.keys": "3.1.2"
+          }
+        }
       }
     },
     "path-parse": {
@@ -9863,15 +9574,16 @@
       }
     },
     "patternfly": {
-      "version": "3.31.2-beta",
-      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.31.2-beta.tgz",
-      "integrity": "sha1-9WBDRiQzuHjWwKPJIjJSTqYuz4Y=",
+      "version": "3.31.2",
+      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.31.2.tgz",
+      "integrity": "sha1-XqvBVjE/2plQhSuil8vnPdp/U2M=",
       "dev": true,
       "requires": {
         "bootstrap": "3.3.7",
         "bootstrap-datepicker": "1.6.4",
         "bootstrap-sass": "3.3.7",
         "bootstrap-select": "1.12.4",
+        "bootstrap-slider": "9.10.0",
         "bootstrap-switch": "3.3.4",
         "bootstrap-touchspin": "3.1.1",
         "c3": "0.4.18",
@@ -9893,31 +9605,221 @@
         "patternfly-bootstrap-treeview": "2.1.5"
       },
       "dependencies": {
+        "bootstrap": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+          "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E=",
+          "dev": true
+        },
+        "bootstrap-datepicker": {
+          "version": "1.6.4",
+          "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.6.4.tgz",
+          "integrity": "sha1-iJ6+ztjqov8V7B8nPksHUxzEPaA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jquery": "3.2.1"
+          }
+        },
+        "bootstrap-sass": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
+          "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg=",
+          "dev": true,
+          "optional": true
+        },
+        "bootstrap-select": {
+          "version": "1.12.4",
+          "resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.12.4.tgz",
+          "integrity": "sha1-fxXTwM6XiGjZwJxw+WYk9V+gLuE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jquery": "3.2.1"
+          }
+        },
+        "bootstrap-slider": {
+          "version": "9.10.0",
+          "resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-9.10.0.tgz",
+          "integrity": "sha1-EQPWvADPv6jPyaJZmrUYxVZD2j8=",
+          "dev": true,
+          "optional": true
+        },
+        "bootstrap-switch": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz",
+          "integrity": "sha1-cOCusqh3wNx2aZHeEI4hcPwpov8=",
+          "dev": true,
+          "optional": true
+        },
+        "bootstrap-touchspin": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz",
+          "integrity": "sha1-l3nerHKq9Xfl52K4USx0fIcdlZc=",
+          "dev": true,
+          "optional": true
+        },
+        "c3": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/c3/-/c3-0.4.18.tgz",
+          "integrity": "sha512-37TiFeCrbe69gg7SxFpTBOLDwulnk+opKp1AFDi43mONtErpRoUIZfGSimGiSYQmNu6Zh9W2yNOx0066UikqSg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "d3": "3.5.17"
+          }
+        },
+        "d3": {
+          "version": "3.5.17",
+          "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+          "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
+          "dev": true,
+          "optional": true
+        },
+        "datatables.net": {
+          "version": "1.10.16",
+          "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.16.tgz",
+          "integrity": "sha1-SwUtEIKCQmG2ju2dInQbcR09JGk=",
+          "dev": true,
+          "requires": {
+            "jquery": "3.2.1"
+          }
+        },
+        "datatables.net-bs": {
+          "version": "1.10.16",
+          "resolved": "https://registry.npmjs.org/datatables.net-bs/-/datatables.net-bs-1.10.16.tgz",
+          "integrity": "sha1-sIVPWzdPcTrj20FWx86op2DD3nY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "datatables.net": "1.10.16",
+            "jquery": "3.2.1"
+          }
+        },
+        "datatables.net-colreorder": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.3.3.tgz",
+          "integrity": "sha1-/HYuNQ+UIkyyzUXCuWImGg//73I=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "datatables.net": "1.10.16",
+            "jquery": "3.2.1"
+          }
+        },
+        "datatables.net-colreorder-bs": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/datatables.net-colreorder-bs/-/datatables.net-colreorder-bs-1.3.3.tgz",
+          "integrity": "sha1-Op3LCN7r612FQHlZHgbkk615OlM=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "datatables.net-bs": "1.10.16",
+            "datatables.net-colreorder": "1.3.3",
+            "jquery": "3.2.1"
+          }
+        },
+        "datatables.net-select": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.2.3.tgz",
+          "integrity": "sha1-fCcugXMqQSFOEBtlb1Ul037Dcog=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "datatables.net": "1.10.16",
+            "jquery": "3.2.1"
+          }
+        },
+        "drmonty-datatables-colvis": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/drmonty-datatables-colvis/-/drmonty-datatables-colvis-1.1.2.tgz",
+          "integrity": "sha1-lque37SGQ8wu3aP4e4iTPN7oEnw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jquery": "3.2.1"
+          }
+        },
+        "eonasdan-bootstrap-datetimepicker": {
+          "version": "4.17.47",
+          "resolved": "https://registry.npmjs.org/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.47.tgz",
+          "integrity": "sha1-ekmXAEQGUnbnll79Fvgic1IZ5zU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bootstrap": "3.3.7",
+            "jquery": "3.2.1",
+            "moment": "2.14.1",
+            "moment-timezone": "0.4.1"
+          }
+        },
+        "font-awesome": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+          "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
+          "dev": true
+        },
+        "font-awesome-sass": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/font-awesome-sass/-/font-awesome-sass-4.7.0.tgz",
+          "integrity": "sha1-TtppPpFQCc4Asijglk3F7Km8NOE=",
+          "dev": true,
+          "optional": true
+        },
+        "google-code-prettify": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/google-code-prettify/-/google-code-prettify-1.0.5.tgz",
+          "integrity": "sha1-n0d/Ik2/piNy5e+AOn4VdBBAAIQ=",
+          "dev": true,
+          "optional": true
+        },
+        "jquery": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+          "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=",
+          "dev": true
+        },
+        "jquery-match-height": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/jquery-match-height/-/jquery-match-height-0.7.2.tgz",
+          "integrity": "sha1-+NnzulMU2qsQnPB0CGdL4gS+Xw4=",
+          "dev": true,
+          "optional": true
+        },
         "moment": {
           "version": "2.14.1",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz",
           "integrity": "sha1-s1snxH5X7S3ccAU9awe+zbKRdBw=",
+          "dev": true
+        },
+        "moment-timezone": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
+          "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "moment": "2.14.1"
+          }
+        },
+        "patternfly-bootstrap-combobox": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/patternfly-bootstrap-combobox/-/patternfly-bootstrap-combobox-1.1.7.tgz",
+          "integrity": "sha1-al48zRFwwhs8S0qhaKdBPh3btuE=",
           "dev": true,
           "optional": true
+        },
+        "patternfly-bootstrap-treeview": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.5.tgz",
+          "integrity": "sha1-TCnyWC+4ovKPCpKPLw0yTSHWmQ0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bootstrap": "3.3.7",
+            "jquery": "3.2.1"
+          }
         }
-      }
-    },
-    "patternfly-bootstrap-combobox": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/patternfly-bootstrap-combobox/-/patternfly-bootstrap-combobox-1.1.7.tgz",
-      "integrity": "sha1-al48zRFwwhs8S0qhaKdBPh3btuE=",
-      "dev": true,
-      "optional": true
-    },
-    "patternfly-bootstrap-treeview": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.5.tgz",
-      "integrity": "sha1-TCnyWC+4ovKPCpKPLw0yTSHWmQ0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bootstrap": "3.3.7",
-        "jquery": "3.2.1"
       }
     },
     "pause-stream": {
@@ -10056,7 +9958,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10129,7 +10031,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10201,7 +10103,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10272,7 +10174,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10343,7 +10245,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10414,7 +10316,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10485,7 +10387,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10557,7 +10459,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10629,7 +10531,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10693,9 +10595,9 @@
       }
     },
     "postcss-loader": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.8.tgz",
-      "integrity": "sha512-KtXBiQ/r/WYW8LxTSJK7h8wLqvCMSub/BqmRnud/Mu8RzwflW9cmXxwsMwbn15TNv287Hcufdb3ZSs7xHKnG8Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.9.tgz",
+      "integrity": "sha512-sgoXPtmgVT3aBAhU47Kig8oPF+mbXl8Unjvtz1Qj1q2D2EvSVJW2mKJNzxv5y/LvA9xWwuvdysvhc7Zn80UWWw==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -10755,7 +10657,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10826,7 +10728,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10873,8 +10775,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000769",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "1.0.30000782",
+            "electron-to-chromium": "1.3.28"
           }
         },
         "chalk": {
@@ -10911,7 +10813,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10990,7 +10892,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11062,7 +10964,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11136,7 +11038,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11210,7 +11112,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11320,7 +11222,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11394,7 +11296,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11466,7 +11368,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11538,7 +11440,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11609,7 +11511,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11682,7 +11584,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11767,7 +11669,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11840,7 +11742,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11919,7 +11821,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11960,9 +11862,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
-      "integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
       "dev": true
     },
     "pretty-format": {
@@ -12013,7 +11915,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0",
+        "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
       }
     },
@@ -12058,9 +11960,9 @@
       }
     },
     "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
@@ -12225,9 +12127,9 @@
       }
     },
     "react": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.1.1.tgz",
-      "integrity": "sha512-FQfiFfk2z2Fk87OngNJHT05KyC9DOVn8LPeB7ZX+9u5+yU1JK6o5ozRlU3PeOMr0IFkWNvgn9jU8/IhRxR1F0g==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
@@ -12278,9 +12180,9 @@
       }
     },
     "react-datetime": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/react-datetime/-/react-datetime-2.11.0.tgz",
-      "integrity": "sha512-LfToQVZrFjH9b+R4PWemo/jJcWawHWHL+eF1HFWGZ9zGXXgy7d/X1+PzJUBYiZfteFM+VSdaHvYyqReqP/nGaQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/react-datetime/-/react-datetime-2.11.1.tgz",
+      "integrity": "sha512-yDZdygP/2zeq02yYnRxid8rDnlUXwCA+0WeHOScc8wZqBnxfkrDEhYJSo/lKaX+85dIU7uuBCuG5oTkl4xXAYQ==",
       "dev": true,
       "requires": {
         "create-react-class": "15.6.2",
@@ -12306,8 +12208,8 @@
         "async": "2.6.0",
         "babel-runtime": "6.26.0",
         "babylon": "5.8.38",
-        "commander": "2.11.0",
-        "doctrine": "2.0.0",
+        "commander": "2.12.2",
+        "doctrine": "2.0.2",
         "node-dir": "0.1.17",
         "recast": "0.12.9"
       },
@@ -12321,9 +12223,9 @@
       }
     },
     "react-dom": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.1.1.tgz",
-      "integrity": "sha512-q06jiwST8SEPAMIEkAsu7BgynEZtqF87VrTc70XsW7nxVhWEu2Y4MF5UfxxHQO/mNtQHQWP0YcFxmwm9oMrMaQ==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
@@ -12365,9 +12267,9 @@
       }
     },
     "react-inspector": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.2.1.tgz",
-      "integrity": "sha512-aXrxJTfriJtZtv/+A9cFIOpfbt711yCD1Ht3fSn3JyuDaAt1+eLtb01R5d/8gGpyquOVWn/d+eM1VPqFXS7UZA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.2.2.tgz",
+      "integrity": "sha512-SzkmYvVUJEmUBuFwGgaGOTGucUBnKXH2wWFdzatkCrawm4P85eqgYvqevHE3DGWpfXqE1pJO4d98TYUANQGCrg==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
@@ -12409,7 +12311,7 @@
       "dev": true,
       "requires": {
         "@types/inline-style-prefixer": "3.0.1",
-        "@types/react": "16.0.25",
+        "@types/react": "16.0.29",
         "inline-style-prefixer": "3.0.8",
         "prop-types": "15.6.0",
         "react-style-proptype": "3.1.0"
@@ -12425,9 +12327,9 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.1.1.tgz",
-      "integrity": "sha512-RV0Krfuc6wDnlv5C/BJzW3e2/s7ZTMZ25gfVjdXdT3hhXNDCQlZucP83HMD8mVh1XScGx9hRaXnIRJ7mE+2N6A==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",
+      "integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
@@ -12554,7 +12456,7 @@
       "dev": true,
       "requires": {
         "ast-types": "0.10.1",
-        "core-js": "2.5.1",
+        "core-js": "2.5.3",
         "esprima": "4.0.0",
         "private": "0.1.8",
         "source-map": "0.6.1"
@@ -12624,7 +12526,7 @@
         "lodash": "4.17.4",
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
-        "symbol-observable": "1.0.4"
+        "symbol-observable": "1.1.0"
       }
     },
     "regenerate": {
@@ -12634,9 +12536,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -13153,7 +13055,7 @@
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "dev": true,
       "requires": {
-        "ajv": "5.4.0"
+        "ajv": "5.5.1"
       }
     },
     "scss-tokenizer": {
@@ -13162,7 +13064,7 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.3.2",
+        "js-base64": "2.4.0",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -13201,6 +13103,18 @@
         "run-auto": "2.0.0",
         "run-series": "1.1.4",
         "semver": "5.4.1"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.4"
+          }
+        }
       }
     },
     "semver": {
@@ -13348,7 +13262,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "interpret": "1.0.4",
+        "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
     },
@@ -13605,7 +13519,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0",
+        "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
       }
     },
@@ -13616,7 +13530,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0",
+        "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
       }
     },
@@ -13720,9 +13634,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw==",
       "dev": true
     },
     "symbol-tree": {
@@ -14071,7 +13985,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.11.0",
+            "commander": "2.12.2",
             "is-my-json-valid": "2.16.1",
             "pinkie-promise": "2.0.1"
           }
@@ -14599,19 +14513,19 @@
       "dev": true
     },
     "webpack": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.9.1.tgz",
-      "integrity": "sha512-jONJ0l8nqgiQVkqs15O9TFWLozbFkCgVodVrBXBK/PIBFeGkaOGo30Ov57iQqYRwAWNDM5vyLPZYmAIpPa5QSw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.4.0",
+        "ajv": "5.5.1",
         "ajv-keywords": "2.1.1",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
-        "interpret": "1.0.4",
+        "interpret": "1.1.0",
         "json-loader": "0.5.7",
         "json5": "0.5.1",
         "loader-runner": "2.3.0",
@@ -14637,22 +14551,30 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
-      "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "dev": true,
       "requires": {
         "memory-fs": "0.4.1",
-        "mime": "1.4.1",
+        "mime": "1.6.0",
         "path-is-absolute": "1.0.1",
         "range-parser": "1.2.0",
         "time-stamp": "2.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        }
       }
     },
     "webpack-hot-middleware": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.20.0.tgz",
-      "integrity": "sha512-AYwVG9DCvMoXbwx8eK16CbJY3Ltwap44lW3T7hFsE0U3zRwtViHMw1DFpY5hMwXNqKsUk3HtNcf3PoV+gIxJeg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.21.0.tgz",
+      "integrity": "sha512-P6xiOLy10QlSVSO7GanU9PLxN6zLLQ7RG16MPTvmFwf2KUG7jMp6m+fmdgsR7xoaVVLA7OlX3YO6JjoZEKjCuA==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -14770,7 +14692,7 @@
       "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
+        "errno": "0.1.6",
         "xtend": "4.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "jest": "^19.0.2",
     "node-sass": "^4.7.2",
-    "patternfly": "^3.31.2-beta",
+    "patternfly": "^3.31.0",
     "prettier": "^1.7.4",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
@@ -63,7 +63,7 @@
     "webpack": "^3.9.1"
   },
   "peerDependencies": {
-    "patternfly": "^3.31.2-beta",
+    "patternfly": "^3.31.0",
     "prop-types": "^15.5.10",
     "react": "^15.6.2 || ^16.0.0",
     "react-dom": "^15.6.2 || ^16.0.0"

--- a/storybook/sass/_patternfly.scss
+++ b/storybook/sass/_patternfly.scss
@@ -1,0 +1,5 @@
+$font-path:      '~patternfly/dist/fonts/';
+$img-path:        '~patternfly/dist/img/';
+$icon-font-path: '~patternfly/dist/fonts/';
+
+@import '~patternfly/dist/sass/patternfly';

--- a/storybook/sass/base.scss
+++ b/storybook/sass/base.scss
@@ -1,7 +1,7 @@
 /**
   PatternFly React Storybook Included Stylesheets
 */
-@import 'patternfly.scss';
+@import 'patternfly';
 
 /**
   Third Party / Dependency LESS imports here
@@ -10,4 +10,4 @@
 /**
   Patternfly React Specific Extensions
 */
-@import '../../sass/patternfly-react.scss';
+@import 'patternfly-react';

--- a/storybook/sass/patternfly.scss
+++ b/storybook/sass/patternfly.scss
@@ -1,1 +1,0 @@
-@import '~patternfly/dist/sass/_patternfly.scss';

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -15,22 +15,25 @@ module.exports = {
       // Sass
       {
         test: /\.scss$/,
-        loaders: ['style-loader', 'css-loader', 'sass-loader'],
-        include: [
-          path.resolve(__dirname, '../sass'),
-          path.resolve(__dirname, '../src'),
-          path.resolve(__dirname, '../node_modules'),
-          path.resolve(__dirname, '../node_modules/patternfly/dist/sass/'),
-          path.resolve(
-            __dirname,
-            '../node_modules/patternfly/dist/sass/patternfly',
-          ),
-          path.resolve(
-            __dirname,
-            '../node_modules/patternfly/dist/sass/patternfly/dependencies',
-          ),
-          path.resolve(__dirname, '../node_modules/bootstrap-sass'),
-          path.resolve(__dirname, './'),
+        use: [
+          { loader: 'style-loader' },
+          { loader: 'css-loader' },
+          {
+            loader: 'sass-loader',
+            options: {
+              includePaths: [
+                path.resolve(__dirname, '../sass'),
+                path.resolve(
+                  __dirname,
+                  '../node_modules/patternfly/node_modules/bootstrap-sass/assets/stylesheets'
+                ),
+                path.resolve(
+                  __dirname,
+                  '../node_modules/patternfly/node_modules/font-awesome-sass/assets/stylesheets'
+                ),
+              ],
+            },
+          },
         ],
       },
       // Images


### PR DESCRIPTION
- Update patternfly to latest release.
- Fix sass build issues by adding `'../node_modules/patternfly/node_modules/bootstrap-sass/assets/stylesheets'`, and `'../node_modules/patternfly/node_modules/font-awesome-sass/assets/stylesheets'` to the webpack sass-loader `includePaths` option.
- Adjust import statements in storybook base and patternfly sass files to be relative to the above paths.
- Change `patternfly.scss` to `_patternfly.scss` to meet sass partial file naming conventions.
- Override patternfly `font-path`, `img-path`, and `icon-font-path` variables to point to the correct location in the context of this project. 